### PR TITLE
docs(env): add .env.example with all referenced variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,47 @@
-# .env 파일을 이 파일 기반으로 만들어 사용하세요 (cp .env.example .env)
+# Copy this file to .env and fill in the values (cp .env.example .env).
+# All variables are optional unless noted otherwise.
 
-# MCP 서버 툴을 GPT(Codex)에 주입할 서버 목록
-# all: ~/.claude.json 에 등록된 모든 서버
-# 쉼표 구분: 지정 서버만 활성화
-# 비워두거나 미설정: MCP 주입 비활성 (기본)
+# ==========================
+# Core HTTP server
+# ==========================
+# Port the proxy listens on (default 19080)
+PORT=19080
+# Max JSON body size for POST /v1/messages (default 20mb)
+PROXY_JSON_LIMIT=20mb
+
+# ==========================
+# Upstream Codex endpoint
+# ==========================
+# Codex base URL (ChatGPT backend). Override only for local testing.
+CODEX_BASE_URL=https://chatgpt.com/backend-api
+
+# ==========================
+# Model mapping overrides
+# ==========================
+# Map anthropic-named models to codex-named ones. Leave blank to use defaults.
+ANTHROPIC_DEFAULT_HAIKU_MODEL=
+ANTHROPIC_DEFAULT_SONNET_MODEL=
+ANTHROPIC_DEFAULT_OPUS_MODEL=
+
+# ==========================
+# Request handling
+# ==========================
+# When "1"/"true", pass the requested model name through unchanged if it's a supported codex model.
+PASSTHROUGH_MODE=
+# Reasoning effort override (low | medium | high | xhigh). Blank = auto.
+PROXY_DEFAULT_EFFORT=
+
+# ==========================
+# MCP tool injection
+# ==========================
+# Which MCP servers from ~/.claude.json to forward to Codex.
+# all        -> every server registered in ~/.claude.json
+# a,b,c      -> only the named servers
+# (blank)    -> MCP injection disabled (default)
 PROXY_MCP_SERVERS=
 
-# Reasoning effort 오버라이드 (low | medium | high | xhigh)
-# 미설정 시: 모델명 테이블 → suffix 파싱(-xhigh/-high/-medium/-low/-spark) → medium 순으로 결정
-# PROXY_DEFAULT_EFFORT=high
-
-# 기타 옵션
-# PORT=19080
-# PROXY_JSON_LIMIT=20mb
-# CODEX_BASE_URL=https://chatgpt.com/backend-api
+# ==========================
+# Signature / routing
+# ==========================
+# Identifies this proxy to downstream callers (appears in response payload).
+CHATGPT_CODEX_PROXY_SIGNATURE=

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ git clone <repo-url>
 cd chatgpt-codex-proxy
 npm install && npm run build
 
+# (optional) Copy the env template and edit values as needed.
+# All variables are optional; PORT and CODEX_BASE_URL have sane defaults.
+cp .env.example .env
+
 # Login with your ChatGPT account (browser opens)
 npm run login
 

--- a/test/env-example-sync.test.ts
+++ b/test/env-example-sync.test.ts
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+function collectSrcEnvKeys(): Set<string> {
+  // grep -rhoE 'process\.env\.[A-Z_]+' src | sort -u
+  const raw = execSync(`grep -rhoE 'process\\.env\\.[A-Z_]+' src`, {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  const keys = new Set<string>();
+  for (const line of raw.split(/\r?\n/)) {
+    const m = line.match(/^process\.env\.([A-Z_][A-Z0-9_]*)$/);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+function collectEnvExampleKeys(): Set<string> {
+  const text = readFileSync(resolve(repoRoot, ".env.example"), "utf8");
+  const keys = new Set<string>();
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Z_][A-Z0-9_]*)\s*=/);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+test(".env.example contains every process.env.* key used in src/", () => {
+  const srcKeys = collectSrcEnvKeys();
+  const envKeys = collectEnvExampleKeys();
+
+  const missing = [...srcKeys].filter((k) => !envKeys.has(k)).sort();
+
+  assert.equal(
+    missing.length,
+    0,
+    `Missing keys in .env.example: ${missing.join(", ")}`,
+  );
+});
+
+test(".env.example does not define keys that are unused in src/", () => {
+  const srcKeys = collectSrcEnvKeys();
+  const envKeys = collectEnvExampleKeys();
+
+  const stale = [...envKeys].filter((k) => !srcKeys.has(k)).sort();
+
+  assert.equal(
+    stale.length,
+    0,
+    `Stale keys in .env.example (not referenced in src/): ${stale.join(", ")}`,
+  );
+});
+
+test("src references at least one env var (sanity check)", () => {
+  const srcKeys = collectSrcEnvKeys();
+  assert.ok(srcKeys.size > 0, "expected to find at least one process.env.* reference in src/");
+});


### PR DESCRIPTION
Closes #12

## Summary
- Add `.env.example` enumerating every `process.env.X` key referenced in `src/` (10 keys total)
- README: add `cp .env.example .env` onboarding step in Quick start
- Add `test/env-example-sync.test.ts` to prevent drift (fails if src keys / .env.example keys diverge)

All values are placeholders — no secrets, no real tokens.

## Keys included
`PORT`, `PROXY_JSON_LIMIT`, `CODEX_BASE_URL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, `PASSTHROUGH_MODE`, `PROXY_DEFAULT_EFFORT`, `PROXY_MCP_SERVERS`, `CHATGPT_CODEX_PROXY_SIGNATURE`

## Test plan
- [x] `npm test` — 6 tests pass (3 new sync tests + 3 existing)
- [x] Manual: `cat .env.example` reviewed, values are placeholders only
- [x] `comm -23 <src-keys> <env-example-keys>` returns empty (no drift)

## Rollback
`git revert <sha>`