### PR TITLE
feat(logging): log sanitizer for credential masking

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -27,6 +27,7 @@ import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { createHash, randomBytes } from "node:crypto";
+import { redactSecrets } from "./utils/sanitize.js";
 
 // OAuth Constants (from OpenAI Codex CLI)
 export const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -131,7 +132,7 @@ export async function exchangeCodeForTokens(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    console.error("[chatgpt-codex-proxy] Token exchange failed:", res.status, text);
+    console.error("[chatgpt-codex-proxy] Token exchange failed:", res.status, redactSecrets(text));
     return null;
   }
 
@@ -174,7 +175,7 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    console.error("[chatgpt-codex-proxy] Token refresh failed:", res.status, text);
+    console.error("[chatgpt-codex-proxy] Token refresh failed:", res.status, redactSecrets(text));
     return null;
   }
 

--- a/src/codex/client.ts
+++ b/src/codex/client.ts
@@ -22,6 +22,7 @@
 import { randomUUID } from "node:crypto";
 import type { CodexRequest } from "../transformers/request.js";
 import { getValidTokens } from "../auth.js";
+import { redactSecrets } from "../utils/sanitize.js";
 
 const CODEX_BASE_URL = process.env.CODEX_BASE_URL ?? "https://chatgpt.com/backend-api";
 const CODEX_RESPONSES_PATH = "/codex/responses";
@@ -156,7 +157,12 @@ export class CodexClient {
       throw new CodexApiError("Could not extract ChatGPT account ID from token.", 401);
     }
 
-    console.log(`[chatgpt-codex-proxy] Calling ${request.model} with effort=${request.reasoning.effort}`);
+    // Wrapping through redactSecrets keeps this log consistent with the
+    // sanitizer contract used elsewhere; model/effort are non-sensitive today
+    // but the hook lets future fields (headers, account id) be safely logged.
+    console.log(
+      redactSecrets(`[chatgpt-codex-proxy] Calling ${request.model} with effort=${request.reasoning.effort}`),
+    );
 
     const codexRequest: CodexRequest = {
       ...request,

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -25,6 +25,7 @@ import { transformCodexToAnthropic } from "../transformers/response.js";
 import type { AnthropicRequest, AnthropicResponse } from "../types/anthropic.js";
 import { ProxyError } from "../utils/errors.js";
 import { mcpToolRegistry } from "../mcp/registry.js";
+import { redactSecrets } from "../utils/sanitize.js";
 
 const router = Router();
 const codexClient = new CodexClient();
@@ -66,7 +67,9 @@ router.post(
         ? `enabled(budget=${body.thinking.budget_tokens ?? "?"})`
         : "disabled";
       console.log(
-        `[chatgpt-codex-proxy] inbound messages model=${body.model} stream=${Boolean(body.stream)} messages=${body.messages.length} thinking=${inboundThinking}`,
+        redactSecrets(
+          `[chatgpt-codex-proxy] inbound messages model=${body.model} stream=${Boolean(body.stream)} messages=${body.messages.length} thinking=${inboundThinking}`,
+        ),
       );
 
       // Transform and call Codex
@@ -93,9 +96,11 @@ router.post(
       const inboundToolNames = (body.tools ?? []).map((tool) => tool.name).join(",");
 
       console.log(
-        `[chatgpt-codex-proxy] tool_plan inbound_parallel=${String(inboundParallel)} effective_parallel=${String(
-          codexRequest.parallel_tool_calls,
-        )} tool_count=${inboundToolCount} inbound_tool_choice=${inboundToolChoice} codex_tool_choice=${String(codexRequest.tool_choice)} tool_names=[${inboundToolNames}]`,
+        redactSecrets(
+          `[chatgpt-codex-proxy] tool_plan inbound_parallel=${String(inboundParallel)} effective_parallel=${String(
+            codexRequest.parallel_tool_calls,
+          )} tool_count=${inboundToolCount} inbound_tool_choice=${inboundToolChoice} codex_tool_choice=${String(codexRequest.tool_choice)} tool_names=[${inboundToolNames}]`,
+        ),
       );
 
       const codexResponse = await codexClient.createResponse(codexRequest);
@@ -113,7 +118,9 @@ router.post(
       const anthropicText = (anthropicResponse.content ?? []).filter((block) => block.type === "text").length;
 
       console.log(
-        `[chatgpt-codex-proxy] tool_diag parallel=${String(codexRequest.parallel_tool_calls)} codex_fn_calls=${codexFunctionCalls} codex_text_blocks=${codexOutputText} anthropic_tool_use=${anthropicToolUse} anthropic_text_blocks=${anthropicText} stop_reason=${anthropicResponse.stop_reason}`,
+        redactSecrets(
+          `[chatgpt-codex-proxy] tool_diag parallel=${String(codexRequest.parallel_tool_calls)} codex_fn_calls=${codexFunctionCalls} codex_text_blocks=${codexOutputText} anthropic_tool_use=${anthropicToolUse} anthropic_text_blocks=${anthropicText} stop_reason=${anthropicResponse.stop_reason}`,
+        ),
       );
 
       // Handle streaming

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import express, { type Request, type Response, type NextFunction } from "express
 import cors from "cors";
 import messagesRouter from "./routes/messages.js";
 import { errorHandler, notFoundHandler } from "./utils/errors.js";
+import { redactSecrets } from "./utils/sanitize.js";
 
 const app = express();
 const jsonBodyLimit = process.env.PROXY_JSON_LIMIT ?? "20mb";
@@ -30,13 +31,14 @@ app.use(express.json({ limit: jsonBodyLimit }));
 
 app.use((req: Request, _res: Response, next: NextFunction) => {
   const startedAt = Date.now();
+  const safeUrl = redactSecrets(req.originalUrl);
   // eslint-disable-next-line no-console
-  console.log(`[REQ] ${req.method} ${req.originalUrl} - ${new Date().toISOString()}`);
+  console.log(`[REQ] ${req.method} ${safeUrl} - ${new Date().toISOString()}`);
 
   _res.on("finish", () => {
     const durationMs = Date.now() - startedAt;
     // eslint-disable-next-line no-console
-    console.log(`[RES] ${req.method} ${req.originalUrl} ${_res.statusCode} - ${durationMs}ms`);
+    console.log(`[RES] ${req.method} ${safeUrl} ${_res.statusCode} - ${durationMs}ms`);
   });
 
   next();

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,0 +1,106 @@
+/**
+ * [파일 목적]
+ * 로그 출력 전에 자격 증명을 마스킹하는 유틸리티.
+ * Bearer 토큰, JWT, OAuth URL 쿼리 파라미터, chatgpt-account-id 헤더,
+ * access_token / refresh_token / authorization 값을 전부 치환한다.
+ *
+ * [주요 흐름]
+ * - redactSecrets(input): 문자열이면 모든 패턴 치환, 객체면 JSON.stringify 후 치환.
+ * - sanitizeString: 단일 문자열에 대한 순수 치환.
+ * - sanitizeObject: 객체의 민감 필드를 재귀적으로 마스킹한 신규 객체 반환.
+ *
+ * [수정시 주의]
+ * - 새 패턴을 추가할 때는 기존 매치 결과에 영향이 없는지 확인한다
+ *   (예: Bearer 치환 후 access_token 치환이 연쇄되면 중복 마스킹 가능).
+ * - 정규식은 greedy 하지 않게 구성하여 정상 텍스트 손실을 막는다.
+ */
+
+const BEARER_RE = /Bearer\s+[A-Za-z0-9._\-+/=]+/g;
+const JWT_RE = /eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g;
+// OAuth / token URL query params (code, state, access_token, refresh_token, id_token, code_verifier, authorization)
+const OAUTH_QUERY_RE =
+  /([?&])(code|state|access_token|refresh_token|id_token|code_verifier|authorization)=([^&\s"'<>]+)/gi;
+// "access_token":"xxx" / "refresh_token":"xxx" / "authorization":"xxx" in JSON-ish strings
+const JSON_FIELD_RE =
+  /("(?:access_token|refresh_token|id_token|authorization|code_verifier)"\s*:\s*")([^"]+)(")/gi;
+// chatgpt-account-id header value (header line or JSON field)
+const ACCOUNT_ID_HEADER_RE =
+  /(["']?chatgpt-account-id["']?\s*[:=]\s*["']?)([^"',\s}>]+)/gi;
+
+/**
+ * Replace all secret-shaped substrings in a plain string.
+ */
+export function sanitizeString(input: string): string {
+  if (typeof input !== "string" || input.length === 0) return input;
+  let out = input;
+  // JWT first, before Bearer could partially consume the trailing dotted payload.
+  out = out.replace(JWT_RE, "***JWT***");
+  out = out.replace(BEARER_RE, "Bearer ***");
+  out = out.replace(OAUTH_QUERY_RE, (_m, sep: string, key: string) => `${sep}${key}=***`);
+  out = out.replace(JSON_FIELD_RE, (_m, prefix: string, _val: string, suffix: string) => `${prefix}***${suffix}`);
+  out = out.replace(ACCOUNT_ID_HEADER_RE, (_m, prefix: string) => `${prefix}***account-id***`);
+  return out;
+}
+
+const SENSITIVE_KEYS = new Set([
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "authorization",
+  "code_verifier",
+  "code",
+  "state",
+  "chatgpt-account-id",
+]);
+
+/**
+ * Return a deep-cloned object with sensitive string fields masked.
+ * Non-sensitive strings are still passed through sanitizeString() so that
+ * embedded Bearer tokens / JWTs / OAuth URLs get redacted.
+ */
+export function sanitizeObject<T>(input: T): T {
+  return cloneWithRedaction(input) as T;
+}
+
+function cloneWithRedaction(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return sanitizeString(value);
+  if (typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => cloneWithRedaction(v));
+  }
+  const src = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(src)) {
+    const raw = src[key];
+    const keyLower = key.toLowerCase();
+    if (SENSITIVE_KEYS.has(keyLower)) {
+      if (typeof raw === "string" && raw.length > 0) {
+        out[key] = keyLower === "chatgpt-account-id" ? "***account-id***" : "***";
+      } else {
+        out[key] = raw;
+      }
+      continue;
+    }
+    out[key] = cloneWithRedaction(raw);
+  }
+  return out;
+}
+
+/**
+ * Convenience: accept a string or object and return a redacted string
+ * suitable for console.log.
+ */
+export function redactSecrets(input: unknown): string {
+  if (input === null || input === undefined) return String(input);
+  if (typeof input === "string") return sanitizeString(input);
+  if (input instanceof Error) {
+    return sanitizeString(`${input.name}: ${input.message}`);
+  }
+  try {
+    const cloned = sanitizeObject(input);
+    return JSON.stringify(cloned);
+  } catch {
+    return sanitizeString(String(input));
+  }
+}

--- a/test/server.log-sanitize.test.ts
+++ b/test/server.log-sanitize.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Integration test: confirm that requests with token-shaped URL query params
+ * do NOT leave the raw token in console.log output produced by the request
+ * logging middleware in src/server.ts.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type AddressInfo } from "node:net";
+import http from "node:http";
+
+import app from "../src/server.js";
+
+function pickPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on("error", reject);
+    srv.listen(0, () => {
+      const { port } = srv.address() as AddressInfo;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+test("request logger does not leak OAuth token from URL", async () => {
+  const port = await pickPort();
+  const server = app.listen(port);
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    logs.push(args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" "));
+  };
+
+  const secretToken = "leakedAccessTokenAbcXyz123";
+  const path = `/does-not-exist?access_token=${secretToken}&code=some-code-123`;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path,
+          method: "GET",
+          headers: { Authorization: "Bearer should-not-be-logged" },
+        },
+        (res) => {
+          res.resume();
+          res.on("end", () => resolve());
+          res.on("error", reject);
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  } finally {
+    // Give the 'finish' listener a tick to fire.
+    await new Promise((r) => setTimeout(r, 20));
+    console.log = origLog;
+    console.error = origErr;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+
+  const joined = logs.join("\n");
+  assert.ok(
+    !joined.includes(secretToken),
+    `access_token leaked in logs: ${joined}`,
+  );
+  assert.ok(
+    !joined.includes("some-code-123"),
+    `OAuth code leaked in logs: ${joined}`,
+  );
+  // Sanity: at least one [REQ] log should have been captured.
+  assert.ok(
+    joined.includes("[REQ] GET"),
+    `request log not captured at all: ${joined}`,
+  );
+  assert.ok(
+    joined.includes("access_token=***"),
+    `sanitized access_token marker missing: ${joined}`,
+  );
+});

--- a/test/utils.sanitize.test.ts
+++ b/test/utils.sanitize.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for src/utils/sanitize.ts
+ *
+ * Validates that redactSecrets() / sanitizeString() / sanitizeObject()
+ * mask Bearer tokens, JWTs, OAuth query params, and chatgpt-account-id
+ * values while leaving non-sensitive text intact.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { redactSecrets, sanitizeObject, sanitizeString } from "../src/utils/sanitize.js";
+
+test("redacts Bearer tokens in strings", () => {
+  const input = "Authorization: Bearer abc123.xyz";
+  const out = sanitizeString(input);
+  assert.ok(!out.includes("abc123.xyz"), `token still present: ${out}`);
+  assert.ok(out.includes("Bearer ***"), `missing Bearer *** marker: ${out}`);
+});
+
+test("redacts JWT payloads", () => {
+  const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+  const input = `token=${jwt}`;
+  const out = sanitizeString(input);
+  assert.ok(!out.includes(jwt), `jwt still present: ${out}`);
+  assert.ok(/\*\*\*JWT\*\*\*|token=\*\*\*/.test(out), `no redaction marker: ${out}`);
+});
+
+test("redacts OAuth URL query params", () => {
+  const input = "http://host/cb?code=secret&state=abc&access_token=xyz";
+  const out = sanitizeString(input);
+  assert.ok(!out.includes("secret"), `code value leaked: ${out}`);
+  assert.ok(!out.includes("abc"), `state value leaked: ${out}`);
+  assert.ok(!out.includes("xyz"), `access_token value leaked: ${out}`);
+  assert.ok(out.includes("code=***"), `missing code=*** : ${out}`);
+  assert.ok(out.includes("state=***"), `missing state=*** : ${out}`);
+  assert.ok(out.includes("access_token=***"), `missing access_token=*** : ${out}`);
+});
+
+test("redacts chatgpt-account-id header values", () => {
+  const obj = { headers: { "chatgpt-account-id": "uuid-value-1234" } };
+  const out = redactSecrets(obj);
+  assert.ok(!out.includes("uuid-value-1234"), `account id leaked: ${out}`);
+  assert.ok(out.includes("***account-id***") || out.includes("***"), `no mask marker: ${out}`);
+});
+
+test("preserves non-sensitive parts", () => {
+  const input = "http://host/api?page=2";
+  const out = sanitizeString(input);
+  assert.equal(out, input);
+});
+
+test("sanitizeObject masks access_token / refresh_token keys", () => {
+  const obj = {
+    access_token: "secret-access",
+    refresh_token: "secret-refresh",
+    user: "alice",
+    nested: { authorization: "Bearer zzz.yyy.xxx" },
+  };
+  const out = sanitizeObject(obj);
+  const json = JSON.stringify(out);
+  assert.ok(!json.includes("secret-access"), `access_token leaked: ${json}`);
+  assert.ok(!json.includes("secret-refresh"), `refresh_token leaked: ${json}`);
+  assert.ok(!json.includes("zzz.yyy.xxx"), `nested authorization leaked: ${json}`);
+  assert.ok(json.includes("alice"), `non-sensitive field dropped: ${json}`);
+});


### PR DESCRIPTION
Closes #1

## Summary
- Add `src/utils/sanitize.ts` exporting `redactSecrets()`, `sanitizeString()`, `sanitizeObject()`
- Apply sanitizer to request/response logs in `src/server.ts`, OAuth failure bodies in `src/auth.ts`, inbound/tool/diag logs in `src/routes/messages.ts`, and the Calling log in `src/codex/client.ts`
- Tests: 6 unit (utils.sanitize.test.ts) + 1 integration (server.log-sanitize.test.ts). Total +7 tests.

## Masking patterns
- `Bearer [...]` -> `Bearer ***`
- JWT (3-segment `eyJ...`) -> `***JWT***`
- OAuth URL query params (`code`, `state`, `access_token`, `refresh_token`, `id_token`, `code_verifier`, `authorization`) -> value replaced with `***`
- `chatgpt-account-id` header / JSON key -> `***account-id***`
- JSON string fields `"access_token" / "refresh_token" / "id_token" / "authorization" / "code_verifier"` -> value replaced with `***`

## Test plan
- [x] `npm test` baseline (3) + new (7) = 10 tests all pass

```
1..10
# tests 10
# suites 0
# pass 10
# fail 0
# cancelled 0
# skipped 0
# todo 0
```

Integration test spins up the Express app on an ephemeral port, captures `console.log/error`, sends a GET with `Authorization: Bearer should-not-be-logged` and `?access_token=leakedAccessTokenAbcXyz123&code=some-code-123`, then asserts that neither raw value appears in captured logs and that the sanitized marker `access_token=***` is present.

## Rollback
```
git revert 74132d7
```
Pure logging utility, no behavioral change to proxy request handling.