### PR TITLE
feat(validate): strict anthropic request validation

### DIFF
--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -24,6 +24,7 @@ import { transformAnthropicToCodex } from "../transformers/request.js";
 import { transformCodexToAnthropic } from "../transformers/response.js";
 import type { AnthropicRequest, AnthropicResponse } from "../types/anthropic.js";
 import { ProxyError } from "../utils/errors.js";
+import { validateAnthropicRequest } from "../utils/validate.js";
 import { mcpToolRegistry } from "../mcp/registry.js";
 
 const router = Router();
@@ -50,17 +51,7 @@ router.post(
 
     try {
       // Validate request
-      if (!body || typeof body !== "object") {
-        throw new ProxyError("Invalid JSON body", 400, "invalid_request_error");
-      }
-
-      if (!body.model || !Array.isArray(body.messages)) {
-        throw new ProxyError(
-          "Missing required fields: model, messages",
-          400,
-          "invalid_request_error"
-        );
-      }
+      validateAnthropicRequest(body);
 
       const inboundThinking = body.thinking?.type === "enabled"
         ? `enabled(budget=${body.thinking.budget_tokens ?? "?"})`
@@ -220,6 +211,11 @@ router.post(
       // Non-streaming response
       res.status(200).json(anthropicResponse);
     } catch (error) {
+      // Preserve ProxyError (e.g., from validateAnthropicRequest) as-is.
+      if (error instanceof ProxyError) {
+        return next(error);
+      }
+
       if (error instanceof CodexApiError) {
         if (error.status === 401) {
           return next(new ProxyError(error.message, 401, "authentication_error"));

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -1,0 +1,110 @@
+/**
+ * [파일 목적]
+ * 이 파일은 Anthropic Messages API 요청 본문의 유효성을 엄격하게 검증한다.
+ * routes/messages.ts의 얕은 검사를 대체하여 잘못된 요청을 라우터 진입 직후에 차단한다.
+ *
+ * [주요 흐름]
+ * 1. body 가 object 인지, model/messages 가 스키마에 부합하는지 확인한다.
+ * 2. tools/tool_choice/max_tokens 등 선택 필드의 형식을 확인한다.
+ * 3. 위반 시 ProxyError(400, "invalid_request_error", ...) 을 던진다.
+ *
+ * [외부 연결]
+ * - routes/messages.ts: 라우트 초입에서 호출
+ * - utils/errors.ts: ProxyError 재사용
+ *
+ * [수정시 주의]
+ * - 에러 메시지 변경 시 클라이언트 디버깅 경험이 달라진다.
+ * - 규칙을 느슨하게 풀면 하위 변환기에서 런타임 오류가 발생할 수 있다.
+ */
+import { ProxyError } from "./errors.js";
+
+const VALID_ROLES = new Set(["user", "assistant"]);
+const VALID_TOOL_CHOICE_TYPES = new Set(["auto", "none", "any", "tool"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(message: string): never {
+  throw new ProxyError(message, 400, "invalid_request_error");
+}
+
+export function validateAnthropicRequest(body: unknown): void {
+  if (!isPlainObject(body)) {
+    fail("Invalid JSON body");
+  }
+
+  const { model, messages, tools, tool_choice, max_tokens } = body as Record<string, unknown>;
+
+  // model: non-empty string
+  if (typeof model !== "string" || model.length === 0) {
+    fail("Invalid request: 'model' must be a non-empty string");
+  }
+
+  // messages: array with length >= 1
+  if (!Array.isArray(messages) || messages.length < 1) {
+    fail("Invalid request: 'messages' must be a non-empty array");
+  }
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!isPlainObject(msg)) {
+      fail(`Invalid request: messages[${i}] must be an object`);
+    }
+    const role = (msg as Record<string, unknown>).role;
+    if (typeof role !== "string" || !VALID_ROLES.has(role)) {
+      fail(`Invalid request: messages[${i}].role must be 'user' or 'assistant'`);
+    }
+    const content = (msg as Record<string, unknown>).content;
+    if (content === undefined || content === null) {
+      fail(`Invalid request: messages[${i}].content is required`);
+    }
+  }
+
+  // tools (optional): must be array of { name, input_schema }
+  if (tools !== undefined) {
+    if (!Array.isArray(tools)) {
+      fail("Invalid request: 'tools' must be an array");
+    }
+    for (let i = 0; i < tools.length; i++) {
+      const tool = tools[i];
+      if (!isPlainObject(tool)) {
+        fail(`Invalid request: tools[${i}] must be an object`);
+      }
+      const toolRecord = tool as Record<string, unknown>;
+      if (typeof toolRecord.name !== "string" || toolRecord.name.length === 0) {
+        fail(`Invalid request: tools[${i}].name must be a non-empty string`);
+      }
+      if (toolRecord.input_schema === undefined || toolRecord.input_schema === null) {
+        fail(`Invalid request: tools[${i}].input_schema is required`);
+      }
+    }
+  }
+
+  // tool_choice (optional)
+  if (tool_choice !== undefined) {
+    if (!isPlainObject(tool_choice)) {
+      fail("Invalid request: 'tool_choice' must be an object");
+    }
+    const tc = tool_choice as Record<string, unknown>;
+    if (typeof tc.type !== "string" || !VALID_TOOL_CHOICE_TYPES.has(tc.type)) {
+      fail("Invalid request: 'tool_choice.type' must be one of auto|none|any|tool");
+    }
+    if (tc.type === "tool") {
+      if (typeof tc.name !== "string" || tc.name.length === 0) {
+        fail("Invalid request: 'tool_choice.name' is required when tool_choice.type is 'tool'");
+      }
+    }
+  }
+
+  // max_tokens (optional): positive integer if provided
+  if (max_tokens !== undefined) {
+    if (
+      typeof max_tokens !== "number" ||
+      !Number.isInteger(max_tokens) ||
+      max_tokens <= 0
+    ) {
+      fail("Invalid request: 'max_tokens' must be a positive integer");
+    }
+  }
+}

--- a/test/messages.validation.test.ts
+++ b/test/messages.validation.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { AddressInfo } from "node:net";
+
+import app from "../src/server.js";
+
+test("POST /v1/messages returns 400 invalid_request_error for invalid body", async () => {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+  const address = server.address() as AddressInfo;
+  const url = `http://127.0.0.1:${address.port}/v1/messages`;
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // Invalid: missing model, empty messages
+      body: JSON.stringify({ messages: [] }),
+    });
+
+    assert.equal(response.status, 400);
+    const json = (await response.json()) as {
+      type: string;
+      error: { type: string; message: string };
+    };
+    assert.equal(json.type, "error");
+    assert.equal(json.error.type, "invalid_request_error");
+    assert.ok(typeof json.error.message === "string" && json.error.message.length > 0);
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+});

--- a/test/validate.request.test.ts
+++ b/test/validate.request.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validateAnthropicRequest } from "../src/utils/validate.js";
+import { ProxyError } from "../src/utils/errors.js";
+
+function expectProxy400(fn: () => void, contains: string): void {
+  try {
+    fn();
+    assert.fail("Expected ProxyError to be thrown");
+  } catch (err) {
+    assert.ok(err instanceof ProxyError, `expected ProxyError, got ${err}`);
+    assert.equal((err as ProxyError).statusCode, 400);
+    assert.equal((err as ProxyError).errorType, "invalid_request_error");
+    assert.ok(
+      (err as ProxyError).message.includes(contains),
+      `expected message to contain "${contains}", got "${(err as ProxyError).message}"`,
+    );
+  }
+}
+
+test("rejects missing model", () => {
+  expectProxy400(
+    () =>
+      validateAnthropicRequest({
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    "model",
+  );
+});
+
+test("rejects empty messages array", () => {
+  expectProxy400(
+    () =>
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [],
+      }),
+    "messages",
+  );
+});
+
+test("rejects tool without name", () => {
+  expectProxy400(
+    () =>
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ input_schema: { type: "object" } }],
+      }),
+    "tools[0].name",
+  );
+});
+
+test("rejects invalid tool_choice type", () => {
+  expectProxy400(
+    () =>
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [{ role: "user", content: "hi" }],
+        tool_choice: { type: "magic" },
+      }),
+    "tool_choice.type",
+  );
+});
+
+test("rejects tool_choice=tool without name", () => {
+  expectProxy400(
+    () =>
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [{ role: "user", content: "hi" }],
+        tool_choice: { type: "tool" },
+      }),
+    "tool_choice.name",
+  );
+});
+
+test("rejects non-positive max_tokens (0 and -1)", () => {
+  expectProxy400(
+    () =>
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 0,
+      }),
+    "max_tokens",
+  );
+  expectProxy400(
+    () =>
+      validateAnthropicRequest({
+        model: "claude-sonnet-4-20250514",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: -1,
+      }),
+    "max_tokens",
+  );
+});
+
+test("accepts minimal valid request", () => {
+  assert.doesNotThrow(() =>
+    validateAnthropicRequest({
+      model: "claude-sonnet-4-20250514",
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 1024,
+    }),
+  );
+});


### PR DESCRIPTION
Closes #3

## Summary
- `src/utils/validate.ts`: `validateAnthropicRequest(body)` throws `ProxyError(400, "invalid_request_error", ...)` on violation. Checks: `model` non-empty string, `messages[].role ∈ {user, assistant}` + `content` present, `tools[].name` + `input_schema` required, `tool_choice.type ∈ {auto, none, any, tool}` with `name` required for `tool`, `max_tokens` positive integer.
- `src/routes/messages.ts`: replaces the shallow `model`/`messages` check with `validateAnthropicRequest(body)`. Adds `ProxyError` pass-through in the catch block so validation errors keep their 400 status instead of being re-wrapped as 500.
- Tests: 7 unit assertions (`test/validate.request.test.ts`) + 1 integration assertion (`test/messages.validation.test.ts`, raw `http` via `fetch` against `app.listen(0)`, no new dep).

## Test plan
`npm test` actual output:
```
1..11
# tests 11
# suites 0
# pass 11
# fail 0
# cancelled 0
# skipped 0
# todo 0
```
- [x] baseline 3 tests still pass (parallel_tool_calls guard)
- [x] 7 unit tests for validate rules pass
- [x] 1 integration test: POST /v1/messages with invalid body returns HTTP 400 + `error.type === "invalid_request_error"`

## Rollback
`git revert <sha>`