### PR TITLE
fix(sse): bound outputTextParts memory growth

### DIFF
--- a/src/codex/client.ts
+++ b/src/codex/client.ts
@@ -219,56 +219,80 @@ export class CodexClient {
   }
 }
 
+// 테스트에서 마지막으로 사용된 outputTextParts 참조를 검사하기 위한 훅.
+// 프로덕션에는 영향이 없고, 메모리 clear 동작을 검증하는 용도로만 쓴다.
+let __lastOutputTextPartsRef: string[] | null = null;
+
 /**
  * SSE stream -> CodexResponse 변환 코어.
  * - delta(output_text.delta) 누적
  * - response.done/completed 중 "마지막으로 도착한" 이벤트가 최종으로 채택됨 (덮어쓰기)
  * - 최종 이벤트가 없으면 누적된 delta로 fallback assistant 메시지 생성
  * - [DONE] sentinel 수신 시 루프 종료
+ * - finalResponse 수신 즉시 outputTextParts를 truncate하여 GC가 수거 가능하게 함
+ *   (긴 응답에서 누적된 delta 배열이 수 MB가 되어도 final 이벤트 후 바로 해제)
+ * - 루프 종료 시에도 defensive clear
  * 테스트에서 재사용하기 위해 별도 함수로 분리하고 __testing__로 노출한다.
  */
 async function collectSseResponse(stream: ReadableStream<Uint8Array>): Promise<CodexResponse> {
   const outputTextParts: string[] = [];
+  __lastOutputTextPartsRef = outputTextParts;
   let finalResponse: CodexResponse | null = null;
 
-  for await (const event of parseSseStream(stream)) {
-    if (event.data === "[DONE]") break;
+  try {
+    for await (const event of parseSseStream(stream)) {
+      if (event.data === "[DONE]") break;
 
-    let parsed: { type?: string; delta?: string; response?: CodexResponse };
-    try {
-      parsed = JSON.parse(event.data);
-    } catch {
-      continue;
+      let parsed: { type?: string; delta?: string; response?: CodexResponse };
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        continue;
+      }
+
+      // Accumulate text deltas
+      if (parsed.type === "response.output_text.delta" && typeof parsed.delta === "string") {
+        outputTextParts.push(parsed.delta);
+      }
+
+      // Capture final response (last wins: response.completed가 response.done 뒤에 오면 완료가 채택됨)
+      if ((parsed.type === "response.done" || parsed.type === "response.completed") && parsed.response) {
+        finalResponse = parsed.response;
+        // final 이벤트 수신 직후 누적 버퍼 해제.
+        // 이후 delta가 더 도착해도 fallback 경로로 가지 않으므로 버려도 안전.
+        outputTextParts.length = 0;
+      }
     }
 
-    // Accumulate text deltas
-    if (parsed.type === "response.output_text.delta" && typeof parsed.delta === "string") {
-      outputTextParts.push(parsed.delta);
+    if (finalResponse) {
+      // 방어적으로 한 번 더 비운다 (위 분기에서 이미 비웠더라도 no-op).
+      outputTextParts.length = 0;
+      return finalResponse;
     }
 
-    // Capture final response (last wins: response.completed가 response.done 뒤에 오면 완료가 채택됨)
-    if ((parsed.type === "response.done" || parsed.type === "response.completed") && parsed.response) {
-      finalResponse = parsed.response;
-    }
+    // Fallback: construct response from accumulated text.
+    // finalResponse가 없을 때만 누적된 delta를 사용하므로 이 경로에서는 clear하지 않는다.
+    const text = outputTextParts.join("");
+    // join 이후에는 더 이상 배열 참조가 필요 없다 → 종료 블록에서 truncate.
+    const fallback: CodexResponse = {
+      id: randomUUID(),
+      model: "codex",
+      output: [
+        {
+          role: "assistant",
+          type: "message",
+          content: [{ type: "output_text", text }],
+        },
+      ],
+      stop_reason: "end_turn",
+    };
+    outputTextParts.length = 0;
+    return fallback;
+  } catch (err) {
+    // 에러로 스트림이 끊어진 경우에도 누적 버퍼 해제.
+    outputTextParts.length = 0;
+    throw err;
   }
-
-  if (finalResponse) {
-    return finalResponse;
-  }
-
-  // Fallback: construct response from accumulated text
-  return {
-    id: randomUUID(),
-    model: "codex",
-    output: [
-      {
-        role: "assistant",
-        type: "message",
-        content: [{ type: "output_text", text: outputTextParts.join("") }],
-      },
-    ],
-    stop_reason: "end_turn",
-  };
 }
 
 /**
@@ -277,4 +301,5 @@ async function collectSseResponse(stream: ReadableStream<Uint8Array>): Promise<C
 export const __testing__ = {
   parseSseStream,
   collectSseResponse,
+  getLastOutputTextPartsRef: () => __lastOutputTextPartsRef,
 };

--- a/test/codex.client.sse-memory.test.ts
+++ b/test/codex.client.sse-memory.test.ts
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { __testing__ } from "../src/codex/client.js";
+
+const { collectSseResponse, getLastOutputTextPartsRef } = __testing__;
+
+/**
+ * 문자열을 ReadableStream<Uint8Array>로 감싼다 (단일 청크).
+ */
+function stringToStream(s: string): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(s));
+      controller.close();
+    },
+  });
+}
+
+/**
+ * delta 이벤트 N개 + finalResponse(response.completed) 한 개를 이어붙인 SSE payload.
+ */
+function buildDeltaPayload(count: number, chunk: string, withFinal: boolean): string {
+  const deltas: string[] = [];
+  for (let i = 0; i < count; i++) {
+    deltas.push(
+      `data: ${JSON.stringify({ type: "response.output_text.delta", delta: chunk })}\n\n`,
+    );
+  }
+  if (withFinal) {
+    const finalEvent = {
+      type: "response.completed",
+      response: {
+        id: "final-id",
+        model: "codex",
+        output: [
+          {
+            role: "assistant",
+            type: "message",
+            content: [{ type: "output_text", text: "FINAL" }],
+          },
+        ],
+      },
+    };
+    deltas.push(`data: ${JSON.stringify(finalEvent)}\n\n`);
+  }
+  deltas.push("data: [DONE]\n\n");
+  return deltas.join("");
+}
+
+test("releases outputTextParts after finalResponse", async () => {
+  // delta 1000개 + response.completed → 파싱 종료 시 내부 배열이 비어 있어야 함.
+  const payload = buildDeltaPayload(1000, "x".repeat(20), true);
+
+  const result = await collectSseResponse(stringToStream(payload));
+
+  // finalResponse가 채택되었는지 확인
+  assert.equal(result.id, "final-id");
+
+  // 내부 outputTextParts 참조가 비어있는지 검증 (메모리 해제 증거)
+  const ref = getLastOutputTextPartsRef();
+  assert.ok(ref, "outputTextParts reference should be captured");
+  assert.equal(ref!.length, 0, "outputTextParts should be cleared after finalResponse");
+});
+
+test("memory usage stays bounded across many deltas with finalResponse", async () => {
+  // 10,000 delta × 100 chars = ~1MB 누적 가능하지만 final 후 clear되어야 함.
+  const payload = buildDeltaPayload(10_000, "x".repeat(100), true);
+
+  // 파싱 전 기준 heap
+  if (global.gc) global.gc();
+  const before = process.memoryUsage().heapUsed;
+
+  const result = await collectSseResponse(stringToStream(payload));
+
+  if (global.gc) global.gc();
+  const after = process.memoryUsage().heapUsed;
+
+  assert.equal(result.id, "final-id");
+
+  // outputTextParts가 해제되었는지 직접 검증 (간접 heap 비교 대신 보장된 assertion)
+  const ref = getLastOutputTextPartsRef();
+  assert.ok(ref);
+  assert.equal(ref!.length, 0, "outputTextParts must be cleared for memory to be bounded");
+
+  // Heap 증가가 10MB를 넘어서지 않아야 함 (환경 의존적이지만 느슨한 상한)
+  const deltaBytes = after - before;
+  assert.ok(
+    deltaBytes < 10 * 1024 * 1024,
+    `heapUsed delta too high: ${deltaBytes} bytes`,
+  );
+});
+
+test("fallback path preserves all deltas when no finalResponse", async () => {
+  // finalResponse 없음 → 100개 delta가 모두 concat되어 fallback 응답의 text로 나와야 함.
+  const chunk = "abc";
+  const payload = buildDeltaPayload(100, chunk, false);
+
+  const result = await collectSseResponse(stringToStream(payload));
+
+  // Fallback 응답 구조 (stop_reason=end_turn)
+  assert.equal(result.stop_reason, "end_turn");
+  assert.equal(result.output.length, 1);
+  const content = result.output[0]!.content!;
+  assert.equal(content[0]!.type, "output_text");
+  assert.equal(content[0]!.text, chunk.repeat(100));
+  assert.equal(content[0]!.text!.length, 100 * chunk.length);
+});
+
+test("handles interleaved delta and non-delta events (final text is delta-only concat)", async () => {
+  // delta / other / delta / other 순서 → 최종 text는 delta만 이어붙인 결과여야 함.
+  const payload =
+    'data: {"type":"response.output_text.delta","delta":"A"}\n\n' +
+    'data: {"type":"response.some_other_event","foo":"bar"}\n\n' +
+    'data: {"type":"response.output_text.delta","delta":"B"}\n\n' +
+    'data: {"type":"response.output_item.added","item":{}}\n\n' +
+    'data: {"type":"response.output_text.delta","delta":"C"}\n\n' +
+    'data: [DONE]\n\n';
+
+  const result = await collectSseResponse(stringToStream(payload));
+
+  // finalResponse 없음 → fallback 경로, delta만 concat
+  assert.equal(result.stop_reason, "end_turn");
+  const content = result.output[0]!.content!;
+  assert.equal(content[0]!.text, "ABC");
+});


### PR DESCRIPTION
Closes #9

## Summary
- src/codex/client.ts: clear outputTextParts after finalResponse
- Fallback path preserved for [DONE] only streams
- 4 new tests

## Test plan
- [x] npm test (37/37)

## Rollback
git revert