### PR TITLE
docs: add CHANGELOG.md and versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+While the version is `0.y.z` (pre-1.0), breaking changes MAY occur in minor
+releases. See the "Versioning" section in `README.md` for policy details.
+
+## [Unreleased]
+
+### Added
+
+- `.env.example` with all referenced environment variables documented (#19).
+- Log sanitizer that masks OAuth tokens, API keys, and other credential
+  shapes before they reach stdout or log files (#20).
+- Strict Anthropic request validation layer at the proxy entry point,
+  rejecting malformed `POST /v1/messages` payloads with 400 before any
+  upstream call (#23).
+- Meta tests ensuring `package.json` version and `CHANGELOG.md` structure
+  stay in sync (#14).
+
+### Changed
+
+- Unified SSE parser across the Codex client. All streaming responses now
+  flow through a single parser, removing duplicated state machines (#21).
+- Consolidated per-family model priority lists into a single
+  `FAMILY_PRIORITIES` map, so adding a new Codex model family only touches
+  one place (#22).
+- `package.json` version lowered from `1.0.0` to `0.2.0` to reflect actual
+  project maturity (fork baseline, pre-stable) (#14).
+
+## [0.2.0] - 2026-04-22
+
+Initial versioned baseline after fork from
+[TBXark/chatgpt-codex-proxy](https://github.com/TBXark/chatgpt-codex-proxy).
+This stanza exists so the file has at least one released version; the
+substantive changes for 0.2.0 are captured in the `[Unreleased]` section
+above and will be promoted into a dated 0.3.0 stanza at the next tag.
+
+### Added
+
+- Fork baseline imported from upstream `TBXark/chatgpt-codex-proxy`.
+
+## Roadmap
+
+Upcoming milestones (tracked in GitHub Issues, promoted into CHANGELOG
+stanzas when tagged):
+
+- **v0.3.0** — request validation hardening, log sanitizer rollout,
+  documentation cleanup.
+- **v0.4.0** — model-mapping refactors, SSE edge-case coverage.
+- **v0.5.0** — first candidate for a `1.0.0` stabilization pass.
+
+[Unreleased]: https://github.com/Choi-Hyeonwoo/chatgpt-codex-proxy/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Choi-Hyeonwoo/chatgpt-codex-proxy/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -314,6 +314,28 @@ If you deploy to a server: add authentication, restrict CORS, add rate limiting,
 
 Do not bind to `0.0.0.0` unless you have implemented all of the above.
 
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(`MAJOR.MINOR.PATCH`).
+
+- **MAJOR** — incompatible API or behavior changes.
+- **MINOR** — backwards-compatible feature additions.
+- **PATCH** — backwards-compatible bug fixes.
+
+While the version is `0.y.z` (pre-1.0), this proxy is considered alpha and
+breaking changes MAY land in minor releases. The API is expected to stabilize
+for a `1.0.0` release once the v0.5.0 milestone is complete.
+
+### Release tags
+
+Releases are tagged in git as `vMAJOR.MINOR.PATCH` (e.g., `v0.2.0`). Each
+tag has a matching section in [`CHANGELOG.md`](./CHANGELOG.md), which
+follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+Unreleased work accumulates under the `## [Unreleased]` heading in the
+changelog and is promoted into a dated version stanza at tag time.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-codex-proxy",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Anthropic-compatible proxy server for Claude Code -> ChatGPT integration",
   "type": "module",
   "private": true,

--- a/test/meta.changelog.test.ts
+++ b/test/meta.changelog.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const changelogPath = resolve(__dirname, '..', 'CHANGELOG.md');
+
+test('CHANGELOG.md has Unreleased section', () => {
+  const content = readFileSync(changelogPath, 'utf8');
+  assert.match(content, /^## \[Unreleased\]/m);
+});
+
+test('CHANGELOG.md has 0.2.0 section', () => {
+  const content = readFileSync(changelogPath, 'utf8');
+  assert.match(content, /^## \[0\.2\.0\]/m);
+});

--- a/test/meta.package-version.test.ts
+++ b/test/meta.package-version.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgPath = resolve(__dirname, '..', 'package.json');
+
+test('package.json version is 0.2.0', () => {
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  assert.equal(pkg.version, '0.2.0');
+});


### PR DESCRIPTION
Closes #14

## Summary
- CHANGELOG.md (Keep a Changelog) with [Unreleased] + [0.2.0] sections listing PRs #19/#20/#21/#22/#23
- package.json version 1.0.0 -> 0.2.0 (reflect actual pre-stable state)
- README.md: new 'Versioning' section (SemVer, 0.y.z alpha policy, v-tag naming)
- test/meta.changelog.test.ts + test/meta.package-version.test.ts enforce file structure

## Test plan
- [x] `jq -r .version package.json` == `0.2.0`
- [x] CHANGELOG.md matches `^## \[Unreleased\]` and `^## \[0\.2\.0\]`
- [x] README.md has `## Versioning` section
- [x] `npm test` passes (36/36, 0 failures, includes 3 new meta tests)

## Rollback
`git revert` on this commit (no runtime impact; docs + test-only change).