### PR TITLE
refactor(auth): extract buildTokenData helper

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -88,6 +88,43 @@ export function decodeJWT(token: string): Record<string, unknown> | null {
 }
 
 /**
+ * Build TokenData from OAuth token response.
+ * Deduplicates the field assembly logic used by both
+ * exchangeCodeForTokens and refreshAccessToken (#4).
+ *
+ * - expires_at = Date.now() + expires_in * 1000
+ * - account_id: response > JWT claim > previous (in that order)
+ * - refresh_token / id_token (if added later): response > previous
+ */
+function buildTokenData(
+  resp: {
+    access_token: string;
+    refresh_token?: string;
+    id_token?: string;
+    expires_in: number;
+    account_id?: string;
+  },
+  previous?: TokenData
+): TokenData {
+  const decoded = decodeJWT(resp.access_token);
+  const authClaim = decoded?.["https://api.openai.com/auth"] as
+    | { chatgpt_account_id?: string }
+    | undefined;
+  const jwtAccountId = authClaim?.chatgpt_account_id;
+
+  return {
+    access_token: resp.access_token,
+    refresh_token: resp.refresh_token ?? previous?.refresh_token ?? "",
+    expires_at: Date.now() + resp.expires_in * 1000,
+    chatgpt_account_id:
+      resp.account_id ?? jwtAccountId ?? previous?.chatgpt_account_id,
+  };
+}
+
+/** @internal Exposed for unit testing only. */
+export const __testing__ = { buildTokenData };
+
+/**
  * Load tokens from file
  */
 export function loadTokens(): TokenData | null {
@@ -147,16 +184,11 @@ export async function exchangeCodeForTokens(
     return null;
   }
 
-  // Extract account ID from JWT
-  const decoded = decodeJWT(json.access_token);
-  const accountId = decoded?.["https://api.openai.com/auth"] as { chatgpt_account_id?: string } | undefined;
-
-  return {
+  return buildTokenData({
     access_token: json.access_token,
     refresh_token: json.refresh_token,
-    expires_at: Date.now() + json.expires_in * 1000,
-    chatgpt_account_id: accountId?.chatgpt_account_id,
-  };
+    expires_in: json.expires_in,
+  });
 }
 
 /**
@@ -189,15 +221,11 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
     return null;
   }
 
-  const decoded = decodeJWT(json.access_token);
-  const accountId = decoded?.["https://api.openai.com/auth"] as { chatgpt_account_id?: string } | undefined;
-
-  return {
+  return buildTokenData({
     access_token: json.access_token,
     refresh_token: json.refresh_token,
-    expires_at: Date.now() + json.expires_in * 1000,
-    chatgpt_account_id: accountId?.chatgpt_account_id,
-  };
+    expires_in: json.expires_in,
+  });
 }
 
 /**

--- a/test/auth.token-data.test.ts
+++ b/test/auth.token-data.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for buildTokenData helper (#4).
+ *
+ * Validates that the extracted helper correctly assembles TokenData
+ * from an OAuth token response: JWT account_id extraction, absence
+ * handling, expires_at math, and malformed JWT tolerance.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { __testing__ } from "../src/auth.js";
+
+const { buildTokenData } = __testing__;
+
+/** Build a 3-segment JWT with the given payload object. */
+function makeJWT(payload: Record<string, unknown>): string {
+  const b64 = (s: string) =>
+    Buffer.from(s, "utf-8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/g, "");
+  const header = b64(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const body = b64(JSON.stringify(payload));
+  const sig = b64("sig");
+  return `${header}.${body}.${sig}`;
+}
+
+test("buildTokenData extracts chatgpt_account_id from JWT", () => {
+  const access = makeJWT({
+    "https://api.openai.com/auth": { chatgpt_account_id: "acc_123" },
+  });
+  const td = buildTokenData({
+    access_token: access,
+    refresh_token: "r",
+    expires_in: 3600,
+  });
+  assert.equal(td.chatgpt_account_id, "acc_123");
+  assert.equal(td.access_token, access);
+  assert.equal(td.refresh_token, "r");
+});
+
+test("buildTokenData handles missing account_id", () => {
+  const access = makeJWT({ sub: "user_1" }); // no auth claim
+  const td = buildTokenData({
+    access_token: access,
+    refresh_token: "r",
+    expires_in: 60,
+  });
+  assert.equal(td.chatgpt_account_id, undefined);
+});
+
+test("buildTokenData computes expires_at = now + expires_in*1000", () => {
+  const before = Date.now();
+  const td = buildTokenData({
+    access_token: makeJWT({}),
+    refresh_token: "r",
+    expires_in: 60,
+  });
+  const after = Date.now();
+  assert.ok(
+    td.expires_at >= before + 60_000 - 1000 &&
+      td.expires_at <= after + 60_000 + 1000,
+    `expires_at ${td.expires_at} outside [${before + 59_000}, ${after + 61_000}]`
+  );
+});
+
+test("buildTokenData returns without account_id for malformed JWT", () => {
+  // 2-segment token — decodeJWT returns null
+  const td = buildTokenData({
+    access_token: "header.payload",
+    refresh_token: "r",
+    expires_in: 60,
+  });
+  assert.equal(td.chatgpt_account_id, undefined);
+  assert.equal(td.access_token, "header.payload");
+});


### PR DESCRIPTION
Closes #4

## Summary
- src/auth.ts: buildTokenData() helper deduplicates lines 131-140 and 173-181
- exchangeCodeForTokens and refreshAccessToken both use the helper
- External signatures preserved
- 4 new unit tests

## Test plan
- [x] npm test (37/37 pass — baseline 33 + new 4)

```
$(cat /tmp/codex-4-test.log)
```

## Rollback
git revert the merge commit

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>