### PR TITLE
feat(stream): SSE backpressure + AbortController

### DIFF
--- a/src/codex/client.ts
+++ b/src/codex/client.ts
@@ -148,7 +148,10 @@ async function* parseSseStream(stream: ReadableStream<Uint8Array>): AsyncGenerat
 }
 
 export class CodexClient {
-  async createResponse(request: CodexRequest): Promise<CodexResponse> {
+  async createResponse(
+    request: CodexRequest,
+    options?: { signal?: AbortSignal },
+  ): Promise<CodexResponse> {
     const tokens = await getValidTokens();
 
     if (!tokens) {
@@ -181,6 +184,7 @@ export class CodexClient {
         "originator": "codex_cli_rs",
       },
       body: JSON.stringify(codexRequest),
+      signal: options?.signal,
     });
 
     if (!response.ok) {

--- a/src/routes/messages.ts
+++ b/src/routes/messages.ts
@@ -27,6 +27,7 @@ import { ProxyError } from "../utils/errors.js";
 import { validateAnthropicRequest } from "../utils/validate.js";
 import { mcpToolRegistry } from "../mcp/registry.js";
 import { createLogger } from "../utils/logger.js";
+import { writeEvent } from "../utils/stream-write.js";
 
 const router = Router();
 const codexClient = new CodexClient();
@@ -50,6 +51,15 @@ router.post(
   "/v1/messages",
   async (req: Request<unknown, AnthropicResponse, AnthropicRequest>, res: Response, next: NextFunction) => {
     const body = req.body;
+
+    // AbortController: 클라이언트 disconnect 시 upstream Codex 호출 중단.
+    const abortController = new AbortController();
+    const onClientClose = () => {
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+    };
+    req.on("close", onClientClose);
 
     try {
       // Validate request
@@ -91,7 +101,9 @@ router.post(
         )} tool_count=${inboundToolCount} inbound_tool_choice=${inboundToolChoice} codex_tool_choice=${String(codexRequest.tool_choice)} tool_names=[${inboundToolNames}]`,
       );
 
-      const codexResponse = await codexClient.createResponse(codexRequest);
+      const codexResponse = await codexClient.createResponse(codexRequest, {
+        signal: abortController.signal,
+      });
       const anthropicResponse = transformCodexToAnthropic(codexResponse, body.model);
 
       const codexFunctionCalls = (codexResponse.output ?? []).filter((item) => item.type === "function_call").length;
@@ -116,7 +128,8 @@ router.post(
         res.setHeader("Connection", "keep-alive");
 
         // message_start
-        res.write(
+        await writeEvent(
+          res,
           `event: message_start\ndata: ${JSON.stringify({
             type: "message_start",
             message: {
@@ -128,40 +141,44 @@ router.post(
               stop_reason: null,
               usage: { input_tokens: 0, output_tokens: 0 },
             },
-          })}\n\n`
+          })}\n\n`,
         );
 
         let blockIndex = 0;
         for (const block of anthropicResponse.content ?? []) {
           if (block.type === "text") {
-            res.write(
+            await writeEvent(
+              res,
               `event: content_block_start\ndata: ${JSON.stringify({
                 type: "content_block_start",
                 index: blockIndex,
                 content_block: { type: "text", text: "" },
-              })}\n\n`
+              })}\n\n`,
             );
 
-            res.write(
+            await writeEvent(
+              res,
               `event: content_block_delta\ndata: ${JSON.stringify({
                 type: "content_block_delta",
                 index: blockIndex,
                 delta: { type: "text_delta", text: block.text ?? "" },
-              })}\n\n`
+              })}\n\n`,
             );
 
-            res.write(
+            await writeEvent(
+              res,
               `event: content_block_stop\ndata: ${JSON.stringify({
                 type: "content_block_stop",
                 index: blockIndex,
-              })}\n\n`
+              })}\n\n`,
             );
             blockIndex += 1;
             continue;
           }
 
           if (block.type === "tool_use") {
-            res.write(
+            await writeEvent(
+              res,
               `event: content_block_start\ndata: ${JSON.stringify({
                 type: "content_block_start",
                 index: blockIndex,
@@ -171,10 +188,11 @@ router.post(
                   name: block.name,
                   input: {},
                 },
-              })}\n\n`
+              })}\n\n`,
             );
 
-            res.write(
+            await writeEvent(
+              res,
               `event: content_block_delta\ndata: ${JSON.stringify({
                 type: "content_block_delta",
                 index: blockIndex,
@@ -182,30 +200,35 @@ router.post(
                   type: "input_json_delta",
                   partial_json: JSON.stringify(block.input ?? {}),
                 },
-              })}\n\n`
+              })}\n\n`,
             );
 
-            res.write(
+            await writeEvent(
+              res,
               `event: content_block_stop\ndata: ${JSON.stringify({
                 type: "content_block_stop",
                 index: blockIndex,
-              })}\n\n`
+              })}\n\n`,
             );
             blockIndex += 1;
           }
         }
 
         // message_delta
-        res.write(
+        await writeEvent(
+          res,
           `event: message_delta\ndata: ${JSON.stringify({
             type: "message_delta",
             delta: { stop_reason: anthropicResponse.stop_reason, stop_sequence: anthropicResponse.stop_sequence ?? null },
             usage: anthropicResponse.usage,
-          })}\n\n`
+          })}\n\n`,
         );
 
         // message_stop
-        res.write(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`);
+        await writeEvent(
+          res,
+          `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+        );
         res.end();
         return;
       }
@@ -213,6 +236,30 @@ router.post(
       // Non-streaming response
       res.status(200).json(anthropicResponse);
     } catch (error) {
+      // 클라이언트가 연결을 끊었다면 abort. upstream 에러는 조용히 종료.
+      if (abortController.signal.aborted) {
+        if (!res.writableEnded) {
+          try {
+            res.end();
+          } catch {
+            // ignore
+          }
+        }
+        return;
+      }
+
+      // fetch AbortError (client disconnect 외 다른 abort) 조기 종료 처리.
+      if (error instanceof Error && (error.name === "AbortError" || (error as { code?: string }).code === "ABORT_ERR")) {
+        if (!res.writableEnded) {
+          try {
+            res.end();
+          } catch {
+            // ignore
+          }
+        }
+        return;
+      }
+
       // Preserve ProxyError (e.g., from validateAnthropicRequest) as-is.
       if (error instanceof ProxyError) {
         return next(error);
@@ -250,6 +297,8 @@ router.post(
       }
 
       next(new ProxyError("Unhandled proxy error", 500, "internal_server_error", { error }));
+    } finally {
+      req.off("close", onClientClose);
     }
   }
 );

--- a/src/utils/stream-write.ts
+++ b/src/utils/stream-write.ts
@@ -1,0 +1,34 @@
+/**
+ * [파일 목적]
+ * SSE 응답 스트림의 backpressure를 처리한다.
+ * res.write()가 false를 반환하면 'drain' 이벤트를 기다린 후 resolve한다.
+ *
+ * [주요 흐름]
+ * 1. write() 호출 → 반환값이 true면 즉시 resolve
+ * 2. false면 drain 이벤트 대기
+ * 3. error 이벤트 발생 시 reject
+ *
+ * [수정시 주의]
+ * - Promise는 항상 settle되어야 함(drain/error 중 하나는 반드시 수신)
+ * - 한 번만 resolve/reject 되도록 once() 사용
+ */
+import type { Writable } from "node:stream";
+
+export function writeEvent(res: Writable, chunk: string | Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (res.write(chunk)) {
+      resolve();
+      return;
+    }
+    const onDrain = () => {
+      res.off("error", onError);
+      resolve();
+    };
+    const onError = (err: Error) => {
+      res.off("drain", onDrain);
+      reject(err);
+    };
+    res.once("drain", onDrain);
+    res.once("error", onError);
+  });
+}

--- a/test/messages.stream-backpressure.test.ts
+++ b/test/messages.stream-backpressure.test.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { writeEvent } from "../src/utils/stream-write.js";
+
+/**
+ * Mock Writable: write()가 미리 설정된 값을 반환하고, error/drain 이벤트를 수동 emit할 수 있음.
+ */
+class MockWritable extends EventEmitter {
+  public writeReturnValues: boolean[] = [];
+  public writeCalls: Array<string | Buffer> = [];
+  private idx = 0;
+
+  write(chunk: string | Buffer): boolean {
+    this.writeCalls.push(chunk);
+    const ret = this.writeReturnValues[this.idx] ?? true;
+    this.idx += 1;
+    return ret;
+  }
+}
+
+test("writeEvent awaits drain when write returns false", async () => {
+  const mock = new MockWritable();
+  mock.writeReturnValues = [false];
+
+  let resolved = false;
+  const p = writeEvent(mock as unknown as import("node:stream").Writable, "chunk").then(
+    () => {
+      resolved = true;
+    },
+  );
+
+  // microtask 소화: drain 없이는 resolve되지 않아야 함
+  await new Promise((r) => setImmediate(r));
+  assert.equal(resolved, false, "must pend until drain");
+
+  // drain emit → resolve
+  mock.emit("drain");
+  await p;
+  assert.equal(resolved, true, "must resolve after drain");
+  assert.equal(mock.writeCalls.length, 1);
+});
+
+test("client disconnect aborts upstream", async () => {
+  // req.on('close') → abort.signal.aborted === true
+  const req = new EventEmitter();
+  const controller = new AbortController();
+  req.on("close", () => {
+    if (!controller.signal.aborted) controller.abort();
+  });
+
+  assert.equal(controller.signal.aborted, false, "initially not aborted");
+
+  req.emit("close");
+
+  assert.equal(controller.signal.aborted, true, "aborted after close");
+});
+
+test("no awaits when write returns true (hot path)", async () => {
+  const mock = new MockWritable();
+  mock.writeReturnValues = [true, true, true];
+
+  // write=true 경로에서는 drain/error 리스너가 등록되지 않아야 함
+  const drainBefore = mock.listenerCount("drain");
+  const errorBefore = mock.listenerCount("error");
+
+  await writeEvent(mock as unknown as import("node:stream").Writable, "a");
+  await writeEvent(mock as unknown as import("node:stream").Writable, "b");
+  await writeEvent(mock as unknown as import("node:stream").Writable, "c");
+
+  assert.equal(mock.listenerCount("drain"), drainBefore, "no drain listener leaked");
+  assert.equal(mock.listenerCount("error"), errorBefore, "no error listener leaked");
+  assert.equal(mock.writeCalls.length, 3);
+});
+
+test("memory bounded under slow drain", async () => {
+  // 100 events × 큰 payload + 각 write마다 false → drain 루프.
+  // 무한 대기 없이 drain emit 시 즉시 다음 write로 진행되어야 함.
+  const mock = new MockWritable();
+  const N = 100;
+  mock.writeReturnValues = new Array(N).fill(false);
+
+  const payload = "x".repeat(10_000); // 10KB per event
+
+  // drain emitter 루프: 매 write 후 micro-delay로 drain emit
+  const writes: Promise<void>[] = [];
+  for (let i = 0; i < N; i++) {
+    const p = writeEvent(mock as unknown as import("node:stream").Writable, payload);
+    writes.push(p);
+    // drain emit을 micro-task로 스케줄하여 다음 write가 진행되게 함
+    await new Promise((r) => setImmediate(r));
+    mock.emit("drain");
+  }
+
+  await Promise.all(writes);
+
+  assert.equal(mock.writeCalls.length, N, "all writes completed");
+  // 리스너 누수 없음
+  assert.equal(mock.listenerCount("drain"), 0, "no drain listener leaked");
+  assert.equal(mock.listenerCount("error"), 0, "no error listener leaked");
+});


### PR DESCRIPTION
Closes #10

## Summary
- src/utils/stream-write.ts: writeEvent awaits drain
- messages.ts: 8 res.write → await writeEvent
- AbortController on req 'close' → propagates to fetch signal
- 4 new tests (57/57 total)

## Rollback
git revert