### PR TITLE
test: expand suite by 15 assertions

### DIFF
--- a/test/codex.probe.test.ts
+++ b/test/codex.probe.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  setRuntimeModelAvailability,
+  firstRuntimeAvailable,
+  runtimeDefaultOpus,
+  FAMILY_PRIORITIES,
+} from "../src/codex/models.js";
+
+test("setRuntimeModelAvailability narrows family selection to runtime-available models", () => {
+  // Simulate a probe result where only gpt-5.3-codex is available (the
+  // first-preferred gpt-5.3-codex-xhigh for opus is NOT available).
+  setRuntimeModelAvailability(["gpt-5.3-codex"]);
+
+  // Confirm the gating works: opus's first-choice xhigh should be skipped,
+  // and the runtime-available gpt-5.3-codex should be selected.
+  const picked = firstRuntimeAvailable(FAMILY_PRIORITIES.opus);
+  assert.equal(picked, "gpt-5.3-codex");
+
+  // Same through the public helper — opus default should fall through to the
+  // first runtime-available option in its priority list.
+  assert.equal(runtimeDefaultOpus(), "gpt-5.3-codex");
+
+  // Reset gating so other tests are not affected.
+  setRuntimeModelAvailability([]);
+});

--- a/test/routes.health.test.ts
+++ b/test/routes.health.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import app from "../src/server.js";
+
+test("GET /health returns 200 and expected shape", async () => {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    const body = await new Promise<{ status: number; json: any }>((resolve, reject) => {
+      const req = http.get({ host: "127.0.0.1", port, path: "/health" }, (res) => {
+        let raw = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => (raw += chunk));
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, json: JSON.parse(raw) });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+      req.on("error", reject);
+    });
+
+    assert.equal(body.status, 200);
+    assert.equal(body.json.status, "ok");
+    assert.ok(body.json.model_overrides, "expected model_overrides field in body");
+    assert.ok("haiku" in body.json.model_overrides);
+    assert.ok("sonnet" in body.json.model_overrides);
+    assert.ok("opus" in body.json.model_overrides);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/test/transformers.request.content.test.ts
+++ b/test/transformers.request.content.test.ts
@@ -1,0 +1,153 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { transformAnthropicToCodex } from "../src/transformers/request.js";
+import type { AnthropicRequest } from "../src/types/anthropic.js";
+
+// Ensure passthrough to avoid family mapping interference
+process.env.PASSTHROUGH_MODE = "1";
+
+function baseRequest(messages: AnthropicRequest["messages"]): AnthropicRequest {
+  return {
+    model: "gpt-5.4",
+    max_tokens: 128,
+    messages,
+  };
+}
+
+test("string content becomes single input_text part", () => {
+  const codex = transformAnthropicToCodex(baseRequest([{ role: "user", content: "hi" }]));
+
+  assert.equal(codex.input.length, 1);
+  const first = codex.input[0];
+  assert.equal(first.type, "message");
+  if (first.type !== "message") return;
+  assert.equal(first.role, "user");
+  assert.ok(Array.isArray(first.content));
+  const parts = first.content as Array<{ type: string; text: string }>;
+  assert.equal(parts.length, 1);
+  assert.equal(parts[0].type, "input_text");
+  assert.equal(parts[0].text, "hi");
+});
+
+test("multi-block text content concatenates into one message preserving order", () => {
+  const codex = transformAnthropicToCodex(
+    baseRequest([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+      },
+    ]),
+  );
+
+  assert.equal(codex.input.length, 1);
+  const msg = codex.input[0];
+  if (msg.type !== "message") throw new Error("expected message");
+  const parts = msg.content as Array<{ type: string; text: string }>;
+  assert.equal(parts.length, 2);
+  assert.equal(parts[0].text, "first");
+  assert.equal(parts[1].text, "second");
+});
+
+test("tool_use block becomes function_call input item with serialized arguments", () => {
+  const codex = transformAnthropicToCodex(
+    baseRequest([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_abc",
+            name: "Bash",
+            input: { command: "ls" },
+          },
+        ],
+      },
+    ]),
+  );
+
+  assert.equal(codex.input.length, 1);
+  const item = codex.input[0];
+  assert.equal(item.type, "function_call");
+  if (item.type !== "function_call") return;
+  assert.equal(item.call_id, "toolu_abc");
+  assert.equal(item.name, "Bash");
+  assert.equal(item.arguments, JSON.stringify({ command: "ls" }));
+});
+
+test("tool_result with string content becomes function_call_output", () => {
+  const codex = transformAnthropicToCodex(
+    baseRequest([
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_abc",
+            content: "output line",
+          },
+        ],
+      },
+    ]),
+  );
+
+  assert.equal(codex.input.length, 1);
+  const item = codex.input[0];
+  assert.equal(item.type, "function_call_output");
+  if (item.type !== "function_call_output") return;
+  assert.equal(item.call_id, "toolu_abc");
+  assert.equal(item.output, "output line");
+});
+
+test("tool_result with is_error and undefined content yields 'Tool execution failed'", () => {
+  const codex = transformAnthropicToCodex(
+    baseRequest([
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_err",
+            is_error: true,
+          },
+        ],
+      },
+    ]),
+  );
+
+  const item = codex.input[0];
+  assert.equal(item.type, "function_call_output");
+  if (item.type !== "function_call_output") return;
+  assert.equal(item.output, "Tool execution failed");
+});
+
+test("image block becomes input_image with data URL", () => {
+  const codex = transformAnthropicToCodex(
+    baseRequest([
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "iVBORw0KGgo=",
+            },
+          },
+        ],
+      },
+    ]),
+  );
+
+  assert.equal(codex.input.length, 1);
+  const msg = codex.input[0];
+  if (msg.type !== "message") throw new Error("expected message");
+  const parts = msg.content as Array<{ type: string; image_url?: string; text?: string }>;
+  assert.equal(parts.length, 1);
+  assert.equal(parts[0].type, "input_image");
+  assert.equal(parts[0].image_url, "data:image/png;base64,iVBORw0KGgo=");
+});

--- a/test/transformers.response.test.ts
+++ b/test/transformers.response.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { transformCodexToAnthropic } from "../src/transformers/response.js";
+import type { CodexResponse } from "../src/codex/client.js";
+import type { ToolUseContentBlock, TextContentBlock } from "../src/types/anthropic.js";
+
+function baseCodexResponse(output: CodexResponse["output"]): CodexResponse {
+  return {
+    id: "resp_test",
+    output,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  } as CodexResponse;
+}
+
+test("function_call with call_id maps to tool_use block using call_id as id", () => {
+  const response = baseCodexResponse([
+    {
+      type: "function_call",
+      call_id: "call_123",
+      id: "fc_abc",
+      name: "Bash",
+      arguments: JSON.stringify({ command: "pwd" }),
+    } as unknown as CodexResponse["output"][number],
+  ]);
+
+  const anthropic = transformCodexToAnthropic(response, "claude-opus-4");
+  assert.equal(anthropic.stop_reason, "tool_use");
+  const toolUse = anthropic.content.find((b) => b.type === "tool_use") as ToolUseContentBlock;
+  assert.ok(toolUse, "expected tool_use block");
+  assert.equal(toolUse.id, "call_123");
+  assert.equal(toolUse.name, "Bash");
+  assert.deepEqual(toolUse.input, { command: "pwd" });
+});
+
+test("function_call without call_id falls back to item id then 'tool_call'", () => {
+  const respWithItemId = baseCodexResponse([
+    {
+      type: "function_call",
+      id: "fc_only",
+      name: "X",
+      arguments: "{}",
+    } as unknown as CodexResponse["output"][number],
+  ]);
+  const a1 = transformCodexToAnthropic(respWithItemId, "m");
+  const t1 = a1.content.find((b) => b.type === "tool_use") as ToolUseContentBlock;
+  assert.equal(t1.id, "fc_only");
+
+  const respWithNoIds = baseCodexResponse([
+    {
+      type: "function_call",
+      name: "X",
+      arguments: "{}",
+    } as unknown as CodexResponse["output"][number],
+  ]);
+  const a2 = transformCodexToAnthropic(respWithNoIds, "m");
+  const t2 = a2.content.find((b) => b.type === "tool_use") as ToolUseContentBlock;
+  assert.equal(t2.id, "tool_call");
+});
+
+test("empty output produces a single empty text block with end_turn stop_reason", () => {
+  const response = baseCodexResponse([]);
+  const anthropic = transformCodexToAnthropic(response, "claude-sonnet-4");
+
+  assert.equal(anthropic.stop_reason, "end_turn");
+  assert.equal(anthropic.content.length, 1);
+  const first = anthropic.content[0] as TextContentBlock;
+  assert.equal(first.type, "text");
+  assert.equal(first.text, "");
+});
+
+test("malformed arguments JSON becomes {raw: <original>}", () => {
+  const response = baseCodexResponse([
+    {
+      type: "function_call",
+      call_id: "call_bad",
+      name: "X",
+      arguments: "not-json{",
+    } as unknown as CodexResponse["output"][number],
+  ]);
+
+  const anthropic = transformCodexToAnthropic(response, "m");
+  const toolUse = anthropic.content.find((b) => b.type === "tool_use") as ToolUseContentBlock;
+  assert.deepEqual(toolUse.input, { raw: "not-json{" });
+});

--- a/test/utils.errors.test.ts
+++ b/test/utils.errors.test.ts
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { ProxyError, formatErrorResponse, errorHandler } from "../src/utils/errors.js";
+
+function makeRes() {
+  const captured: { statusCode?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      captured.statusCode = code;
+      return res;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return res;
+    },
+  };
+  return { res, captured };
+}
+
+test("ProxyError round-trips statusCode and errorType via formatErrorResponse", () => {
+  const err = new ProxyError("boom", 418, "teapot_error", { hint: "brew" });
+  assert.equal(err.statusCode, 418);
+  assert.equal(err.errorType, "teapot_error");
+  assert.deepEqual(err.details, { hint: "brew" });
+
+  const body = formatErrorResponse(err);
+  assert.equal(body.type, "error");
+  assert.equal(body.error.type, "teapot_error");
+  assert.equal(body.error.message, "boom");
+});
+
+test("errorHandler maps entity.too.large to 413 request_too_large", () => {
+  const { res, captured } = makeRes();
+  const err = { type: "entity.too.large" } as unknown;
+  errorHandler(err, {} as any, res as any, (() => {}) as any);
+
+  assert.equal(captured.statusCode, 413);
+  const body = captured.body as { type: string; error: { type: string; message: string } };
+  assert.equal(body.type, "error");
+  assert.equal(body.error.type, "request_too_large");
+  assert.ok(body.error.message.toLowerCase().includes("too large"));
+});
+
+test("errorHandler maps SyntaxError with body prop to 400 invalid_request_error", () => {
+  const { res, captured } = makeRes();
+  const err = new SyntaxError("Unexpected token");
+  (err as unknown as { body: string }).body = "{bad";
+  errorHandler(err, {} as any, res as any, (() => {}) as any);
+
+  assert.equal(captured.statusCode, 400);
+  const body = captured.body as { type: string; error: { type: string; message: string } };
+  assert.equal(body.error.type, "invalid_request_error");
+  assert.equal(body.error.message, "Invalid JSON body");
+});


### PR DESCRIPTION
Closes #11

## Summary
- 5 new test files: transformers.request.content, transformers.response, utils.errors, codex.probe, routes.health
- 15 new assertions. Total 68+ pass.

## Rollback
git revert