### PR TITLE
feat(auth): token refresh cache with concurrent dedup (#8)

### DIFF
--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -27,6 +27,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { createLogger } from "../utils/logger.js";
 import { buildTokenData } from "./jwt.js";
 import { loadTokens, saveTokens, type TokenData } from "./token-storage.js";
+import { getValidToken as _getCachedToken, setRefreshFn } from "./token-cache.js";
 
 const log = createLogger("auth");
 
@@ -144,25 +145,32 @@ export async function refreshAccessToken(refreshToken: string): Promise<TokenDat
   });
 }
 
+// Register the refresh function into token-cache (avoids circular import).
+// This runs once at module load time.
+setRefreshFn(async () => {
+  const stored = loadTokens();
+  if (!stored) throw new Error("No stored tokens for refresh");
+  const newTokens = await refreshAccessToken(stored.refresh_token);
+  if (!newTokens) throw new Error("Token refresh returned null");
+  saveTokens(newTokens);
+  return newTokens;
+});
+
 /**
- * Get valid tokens (refresh if needed)
+ * Get valid tokens (refresh if needed).
+ * Delegates to token-cache for in-memory caching and concurrent dedup (#8).
+ * Returns null only when no stored tokens exist (not logged in).
  */
 export async function getValidTokens(): Promise<TokenData | null> {
-  const tokens = loadTokens();
-  if (!tokens) return null;
+  // If there are no stored tokens, user is not logged in.
+  const stored = loadTokens();
+  if (!stored) return null;
 
-  // Refresh if expired (with 5 min buffer)
-  if (Date.now() >= tokens.expires_at - 5 * 60 * 1000) {
-    log.info("Token expired, refreshing...");
-    const newTokens = await refreshAccessToken(tokens.refresh_token);
-    if (newTokens) {
-      saveTokens(newTokens);
-      return newTokens;
-    }
+  try {
+    return await _getCachedToken();
+  } catch {
     return null;
   }
-
-  return tokens;
 }
 
 /**

--- a/src/auth/token-cache.ts
+++ b/src/auth/token-cache.ts
@@ -1,0 +1,101 @@
+/**
+ * [파일 목적]
+ * 인메모리 토큰 캐시 + 동시 refresh 중복 제거(dedup)를 담당한다.
+ * - 만료 5분 전 pre-refresh (BUFFER_MS)
+ * - 동시 N개 요청이 동일 만료 토큰 발견 시 refresh는 1회만 실행,
+ *   나머지는 진행 중인 Promise를 공유해 대기 후 같은 결과 수신.
+ *
+ * [주요 흐름]
+ * 1. getValidToken 호출
+ * 2. 캐시 유효 → 즉시 반환
+ * 3. 이미 refresh 진행 중 → 기존 Promise 반환 (dedup)
+ * 4. refresh 필요 → refreshFn()으로 새 토큰 획득, 캐시 갱신
+ *
+ * [외부 연결]
+ * - refreshFn: 외부에서 주입 (순환 참조 방지). oauth.ts가 setRefreshFn으로 등록.
+ * - token-storage.ts: loadTokens, saveTokens, TokenData
+ *
+ * [수정시 주의]
+ * - BUFFER_MS를 바꾸면 oauth.ts의 5분 버퍼 설명과 일치시켜야 한다.
+ * - refreshPromise 리셋은 finally에서 반드시 실행되어야 실패 후 재시도가 가능하다.
+ * - 테스트에서 _resetCache()로 모듈 상태를 초기화할 수 있다.
+ */
+
+import { type TokenData } from "./token-storage.js";
+
+/** 만료 5분 전에 미리 갱신 */
+export const BUFFER_MS = 5 * 60 * 1000;
+
+let cached: TokenData | null = null;
+let refreshPromise: Promise<TokenData> | null = null;
+
+/** 주입된 refresh 함수 타입 */
+export type RefreshFn = () => Promise<TokenData>;
+
+let _refreshFn: RefreshFn | null = null;
+
+/**
+ * refresh 함수를 외부에서 주입 (순환 참조 방지용 DI).
+ * oauth.ts 초기화 시점에 한 번 호출.
+ */
+export function setRefreshFn(fn: RefreshFn): void {
+  _refreshFn = fn;
+}
+
+/**
+ * 실제 refresh 수행
+ */
+async function doRefresh(): Promise<TokenData> {
+  if (!_refreshFn) {
+    throw new Error("token-cache: refreshFn not set. Call setRefreshFn() first.");
+  }
+  return _refreshFn();
+}
+
+/**
+ * 유효한 토큰 반환.
+ * - 인메모리 캐시가 유효하면 즉시 반환
+ * - refresh 진행 중이면 동일 Promise 반환 (dedup)
+ * - 그 외 refresh 실행 후 캐시 갱신
+ */
+export async function getValidToken(): Promise<TokenData> {
+  // 캐시 유효성 확인 (buffer 포함)
+  if (cached !== null && cached.expires_at - BUFFER_MS > Date.now()) {
+    return cached;
+  }
+
+  // 이미 진행 중인 refresh가 있으면 공유 (dedup)
+  if (refreshPromise !== null) {
+    return refreshPromise;
+  }
+
+  // 새 refresh 시작
+  refreshPromise = doRefresh().finally(() => {
+    refreshPromise = null;
+  });
+
+  try {
+    cached = await refreshPromise;
+    return cached;
+  } catch (err) {
+    // refresh 실패 시 캐시 무효화
+    cached = null;
+    throw err;
+  }
+}
+
+/**
+ * 캐시를 명시적으로 설정 (외부에서 새 토큰을 받았을 때 사용)
+ */
+export function setCachedToken(token: TokenData): void {
+  cached = token;
+}
+
+/**
+ * @internal 테스트 전용 — 모듈 인메모리 상태 초기화
+ */
+export function _resetCache(): void {
+  cached = null;
+  refreshPromise = null;
+  _refreshFn = null;
+}

--- a/test/auth.token-cache.test.ts
+++ b/test/auth.token-cache.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for src/auth/token-cache.ts (#8)
+ *
+ * Tests:
+ * 1. Fresh cache (expires_at = now + 10 min) → refresh never called
+ * 2. Buffer zone (expires_at = now + 1 min, inside BUFFER_MS) → refresh called once
+ * 3. 100 concurrent getValidToken() → mockRefresh called exactly once (dedup)
+ * 4. Refresh failure → refreshPromise reset to null, next call retries
+ * 5. Hard expired (expires_at = now - 1) → refresh called
+ */
+
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Import the module under test AFTER resetting state for each test
+const cacheMod = await import("../src/auth/token-cache.js");
+
+const { getValidToken, setRefreshFn, _resetCache, BUFFER_MS } = cacheMod;
+
+function makeToken(expiresIn: number) {
+  return {
+    access_token: "at_test",
+    refresh_token: "rt_test",
+    expires_at: Date.now() + expiresIn,
+    chatgpt_account_id: "acc_test",
+  };
+}
+
+// Reset cache state before each test
+beforeEach(() => {
+  _resetCache();
+});
+
+// ── Test 1: fresh cache, no refresh ──────────────────────────────────────────
+test("fresh cache (expires_at = now + 10min) returns cached token without calling refresh", async () => {
+  let refreshCallCount = 0;
+  const freshToken = makeToken(10 * 60 * 1000); // 10 min
+
+  setRefreshFn(async () => {
+    refreshCallCount++;
+    return freshToken;
+  });
+
+  // Prime the cache with first call
+  const first = await getValidToken();
+  assert.equal(refreshCallCount, 1, "First call should trigger refresh");
+  assert.equal(first.access_token, "at_test");
+
+  // Second call should hit cache
+  const second = await getValidToken();
+  assert.equal(refreshCallCount, 1, "Second call must not trigger refresh");
+  assert.equal(second.access_token, "at_test");
+});
+
+// ── Test 2: buffer zone triggers refresh ─────────────────────────────────────
+test("token inside BUFFER_MS window triggers refresh", async () => {
+  let refreshCallCount = 0;
+  // Token that expires in 1 min (less than BUFFER_MS = 5 min) → stale
+  const staleToken = makeToken(60 * 1000); // 1 min
+  const newToken = makeToken(60 * 60 * 1000); // 60 min
+
+  setRefreshFn(async () => {
+    refreshCallCount++;
+    return newToken;
+  });
+
+  // Manually prime cache with a stale token by calling setCachedToken
+  cacheMod.setCachedToken(staleToken);
+
+  // getValidToken should detect it's within BUFFER_MS and refresh
+  const result = await getValidToken();
+  assert.equal(refreshCallCount, 1, "Should refresh once for buffer-zone token");
+  assert.equal(result.expires_at, newToken.expires_at);
+});
+
+// ── Test 3: 100 concurrent calls → exactly 1 refresh ────────────────────────
+test("100 concurrent getValidToken() calls trigger refresh exactly once", async () => {
+  let refreshCallCount = 0;
+  const freshToken = makeToken(60 * 60 * 1000); // 60 min, won't expire
+
+  setRefreshFn(async () => {
+    refreshCallCount++;
+    // Simulate async work (e.g., network I/O)
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    return freshToken;
+  });
+
+  // Fire 100 concurrent calls
+  const results = await Promise.all(
+    Array.from({ length: 100 }, () => getValidToken())
+  );
+
+  assert.equal(refreshCallCount, 1, "Exactly 1 refresh must happen for 100 concurrent calls");
+  assert.equal(results.length, 100);
+  // All results should point to the same token data
+  for (const r of results) {
+    assert.equal(r.access_token, freshToken.access_token);
+  }
+});
+
+// ── Test 4: refresh failure resets refreshPromise ────────────────────────────
+test("refresh failure resets refreshPromise so next call can retry", async () => {
+  let callCount = 0;
+  const goodToken = makeToken(60 * 60 * 1000);
+
+  setRefreshFn(async () => {
+    callCount++;
+    if (callCount === 1) {
+      throw new Error("Network error");
+    }
+    return goodToken;
+  });
+
+  // First call — should fail
+  await assert.rejects(
+    () => getValidToken(),
+    /Network error/,
+    "First call should throw"
+  );
+
+  // refreshPromise must be null after failure so next call retries
+  // Second call — should succeed
+  const result = await getValidToken();
+  assert.equal(callCount, 2, "Second call should trigger a new refresh attempt");
+  assert.equal(result.access_token, goodToken.access_token);
+});
+
+// ── Test 5: hard expired token triggers refresh ──────────────────────────────
+test("hard expired token (expires_at = now - 1ms) triggers refresh", async () => {
+  let refreshCallCount = 0;
+  const expiredToken = makeToken(-1); // already expired
+  const newToken = makeToken(60 * 60 * 1000);
+
+  setRefreshFn(async () => {
+    refreshCallCount++;
+    return newToken;
+  });
+
+  // Prime cache with expired token
+  cacheMod.setCachedToken(expiredToken);
+
+  const result = await getValidToken();
+  assert.equal(refreshCallCount, 1, "Expired token must trigger refresh");
+  assert.equal(result.expires_at, newToken.expires_at);
+});


### PR DESCRIPTION
Closes #8.

## Summary
- New `src/auth/token-cache.ts` with 5-minute pre-refresh buffer and concurrent refresh dedup via shared Promise
- `oauth.ts getValidTokens()` routed through the cache (`_getCachedToken`)
- `setRefreshFn` DI pattern prevents circular import between `oauth.ts` ↔ `token-cache.ts`
- `_resetCache()` / `setCachedToken()` exported for test isolation

## Test plan
- [x] `npm test` passes: 84/84 (5 new token-cache tests: ok 5–9)
- [x] Concurrent dedup verified: 100 parallel calls → 1 refresh invocation
- [x] Failure reset verified: refresh error → `refreshPromise = null` → next call retries
- [x] Buffer zone verified: token expiring in 1 min (< 5-min buffer) triggers pre-refresh